### PR TITLE
display SOC for additionalSource

### DIFF
--- a/src/components/energyFlow/energyPoint.tsx
+++ b/src/components/energyFlow/energyPoint.tsx
@@ -4,6 +4,7 @@ import {useTheme2} from "@grafana/ui";
 interface PointProps {
   label: string;
   value: number;
+  subValue?: number;
   style: any;
   icon: string;
   showLegend?: any;
@@ -59,6 +60,10 @@ function legendComponent(fontColor: string, label: string) {
           <path
             d={props.icon}/>
         </svg>
+        { props.subValue && (
+              <text fontSize={12} fill={fontColor} x="100" y="148"
+                  textAnchor="middle">{props.subValue + "%"}</text>
+	)}
         <br/>
       </svg>
       {/*<text className={"m"}>{props.label}</text>*/}

--- a/src/components/energyFlow/index.tsx
+++ b/src/components/energyFlow/index.tsx
@@ -22,6 +22,7 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
   let grid = 0;
   let pv = 0;
   let additionalSource = 0;
+  let additionalSourceSOC = 0;
 
   // Look for matching data in the series
   for(let seriesIndex = 0; seriesIndex < data.series.length; seriesIndex++) {
@@ -40,6 +41,11 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
         additionalSource = data.series[seriesIndex].fields[fieldIndex].values[0];
       }
     }
+    for(let fieldIndex = 0; fieldIndex < data.series[seriesIndex].fields.length; fieldIndex++) {
+      if (data.series[seriesIndex].fields[fieldIndex].name === options.additionalSourceSOCQuery) {
+        additionalSourceSOC = data.series[seriesIndex].fields[fieldIndex].values[0];
+      }
+    }
   }
 
   const [flowData, setFlowData] = React.useState<FlowData>({
@@ -47,13 +53,14 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
     load: 0,
     grid: 0,
     additionalSource: 0,
+    additionalSourceSOC: 0,
   });
 
   useEffect(() => {
     (async () => {
-      setFlowData(await EnergyFlowCore.calculateNewFlowData(pv, grid, additionalSource, options.measurementUnit));
+      setFlowData(await EnergyFlowCore.calculateNewFlowData(pv, grid, additionalSource, additionalSourceSOC, options.measurementUnit));
     })();
-  }, [grid, pv, additionalSource, options.measurementUnit]);
+  }, [grid, pv, additionalSource, additionalSourceSOC, options.measurementUnit]);
 
   const pvPoint: PointPosition = {x: 275, y: 250};
   const loadPoint: PointPosition = {x: 100, y: 460};
@@ -103,9 +110,10 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
             <Point label="PV" measurementUnit={options.measurementUnit} showLegend={false} value={flowData.pv}
                    style={customPoint(theme.visualization.getColorByName(options.solarColor))} icon={icons["solarPanel"]} />
           </div>
-          {flowData.additionalSource !== 0 && (
+          {(flowData.additionalSource !== 0 || flowData.additionalSourceSOC !== 0) && (
             <div className="point-holder" style={{ position: 'absolute', top: '100px', left: '150px' }}>
               <Point label={options.additionalSourceLabel} measurementUnit={options.measurementUnit} showLegend={options.showLegend} value={flowData.additionalSource}
+                     subValue={flowData.additionalSourceSOC}
                      style={customPoint(theme.visualization.getColorByName(options.additionalSourceColor))} icon={icons[options.additionalSourceIcon]} />
             </div>
           )}

--- a/src/models/flow/index.ts
+++ b/src/models/flow/index.ts
@@ -5,6 +5,7 @@ export interface FlowData {
  grid: number;
  load: number;
  additionalSource: number;
+ additionalSourceSOC: number;
 }
 
 export interface CustomXarrowProps {

--- a/src/module.ts
+++ b/src/module.ts
@@ -22,6 +22,12 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
       description: 'Select the field for the Additional source (Battery, EV Panel, etc.) - Deselect to remove',
       defaultValue: '',
     })
+    .addFieldNamePicker({
+      path: "additionalSourceSOCQuery",
+      name: 'Additional Source SOC Value',
+      description: 'Select the field for the Additional sources SOC (Battery, EV Panel, etc.) - Deselect to remove',
+      defaultValue: '',
+    })
     .addTextInput({
       path: 'additionalSourceLabel',
       name: 'Additional Source Label',

--- a/src/services/energyFlowCore/index.ts
+++ b/src/services/energyFlowCore/index.ts
@@ -1,7 +1,7 @@
 import {FlowData} from "../../models/flow";
 
 export class EnergyFlowCore {
-  public static async calculateNewFlowData(pv: number, grid: number, additionalSource: number, unit: 'W' | 'kW' | 'MW'): Promise<FlowData> {
+  public static async calculateNewFlowData(pv: number, grid: number, additionalSource: number, additionalSourceSOC: number, unit: 'W' | 'kW' | 'MW'): Promise<FlowData> {
     const unitFactor
       = unit === 'W' ? 1
       : unit === 'kW' ? 1000
@@ -13,6 +13,7 @@ export class EnergyFlowCore {
       grid: Number((grid / unitFactor).toFixed(3)),
       load: Number(((pv + grid + (additionalSource !== 0 ? additionalSource : 0)) / unitFactor).toFixed(3)),
       additionalSource: Number((additionalSource / unitFactor).toFixed(3)),
+      additionalSourceSOC: Number(additionalSourceSOC.toFixed(0)),
     };
 
     return data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface SimpleOptions {
   solarQuery: any;
   gridQuery: any;
   additionalSourceLoadQuery: any;
+  additionalSourceSOCQuery: any;
   additionalSourceLabel: string;
   additionalSourceIcon: string;
   additionalSourceColor: string;


### PR DESCRIPTION
I've added the option to display a SOC value for additional Source:  
![grafik](https://github.com/user-attachments/assets/61cb57cb-d72d-4b44-aa31-e40685b1c5da)

I've added a new property `subValue` to energyPoint, that is compatible with all 3 other icons, so they - in theory - can also show additional information. 

However this subValue property is only used for the additional Source.