### PR TITLE
Add option to always show additional source

### DIFF
--- a/src/components/energyFlow/energyLine.tsx
+++ b/src/components/energyFlow/energyLine.tsx
@@ -9,17 +9,18 @@ interface EnergyLinesProps {
  gridPoint: PointPosition;
  extraEnergyPoint: PointPosition;
  linesColor: string;
+ alwaysShowAdditionalSource: boolean;
 }
 
 
-export const EnergyLines: React.FC<EnergyLinesProps> = ({flow, pvPoint, loadPoint, gridPoint, extraEnergyPoint, linesColor}) => {
+export const EnergyLines: React.FC<EnergyLinesProps> = ({flow, pvPoint, loadPoint, gridPoint, extraEnergyPoint, linesColor, alwaysShowAdditionalSource}) => {
   return (
     <>
       <EmptyLine start={{x: pvPoint.x + 2, y: loadPoint.y}} end={gridPoint}/>
       <EmptyLine start={pvPoint} end={{x: pvPoint.x, y: loadPoint.y - 2}}/>
       <EmptyLine start={{x: pvPoint.x - 2, y: loadPoint.y}} end={loadPoint}/>
 
-      {flow.additionalSource !== 0 && (
+      {flow.additionalSource !== 0 || alwaysShowAdditionalSource && (
         <>
           <EmptyLine start={extraEnergyPoint} end={{x: pvPoint.x, y: loadPoint.y + 2}}/>
           <EnergyLine start={extraEnergyPoint} end={{x: pvPoint.x, y: loadPoint.y }} linesColor={linesColor} className={flow.additionalSource < 0 ? "animated-line" : "animated-line-reverse"}/>

--- a/src/components/energyFlow/index.tsx
+++ b/src/components/energyFlow/index.tsx
@@ -94,7 +94,7 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
                viewBox='0 0 500 500'>
             <EnergyLines flow={flowData} pvPoint={pvPoint}
                          linesColor={(theme.visualization.getColorByName(options.linesColor))} loadPoint={loadPoint}
-                         gridPoint={gridPoint} extraEnergyPoint={additionalPoint} />
+                         gridPoint={gridPoint} extraEnergyPoint={additionalPoint} alwaysShowAdditionalSource={options.additionalSourceAlwaysShow}/>
           </svg>
         </div>
 

--- a/src/components/energyFlow/index.tsx
+++ b/src/components/energyFlow/index.tsx
@@ -103,7 +103,7 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
             <Point label="PV" measurementUnit={options.measurementUnit} showLegend={false} value={flowData.pv}
                    style={customPoint(theme.visualization.getColorByName(options.solarColor))} icon={icons["solarPanel"]} />
           </div>
-          {flowData.additionalSource !== 0 && (
+          {flowData.additionalSource !== 0 || options.additionalSourceAlwaysShow && (
             <div className="point-holder" style={{ position: 'absolute', top: '100px', left: '150px' }}>
               <Point label={options.additionalSourceLabel} measurementUnit={options.measurementUnit} showLegend={options.showLegend} value={flowData.additionalSource}
                      style={customPoint(theme.visualization.getColorByName(options.additionalSourceColor))} icon={icons[options.additionalSourceIcon]} />

--- a/src/module.ts
+++ b/src/module.ts
@@ -28,6 +28,12 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
       description: 'Label for the Additional source',
       defaultValue: 'Battery',
     })
+    .addBooleanSwitch({
+      path: 'additionalSourceAlwaysShow',
+      name: 'Always show additional source',
+      description: 'Always show the additional source, even if input is 0',
+      defaultValue: false,
+    })
     .addSelect({
       path: 'measurementUnit',
       name: 'Select Measurement Unit',
@@ -124,12 +130,6 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
       path: 'showLegend',
       name: 'Show legend',
       description: 'Label the energy points',
-      defaultValue: false,
-    })
-    .addBooleanSwitch({
-      path: 'additionalSourceAlwaysShow',
-      name: 'Always show additional source',
-      description: 'Always show the additional source, even if input is 0',
       defaultValue: false,
     });
 });

--- a/src/module.ts
+++ b/src/module.ts
@@ -125,5 +125,11 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
       name: 'Show legend',
       description: 'Label the energy points',
       defaultValue: false,
+    })
+    .addBooleanSwitch({
+      path: 'additionalSourceAlwaysShow',
+      name: 'Always show additional source',
+      description: 'Always show the additional source, even if input is 0',
+      defaultValue: false,
     });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,5 +20,6 @@ export interface SimpleOptions {
   additionalSourceLabel: string;
   additionalSourceIcon: string;
   additionalSourceColor: string;
+  additionalSourceAlwaysShow: boolean;
   measurementUnit: 'W' | 'kW' | 'MW';
 }


### PR DESCRIPTION
If the option is set to true (it defaults to false), the additional Source is always shown (even when there is no power from that source).