### PR TITLE
Add option to hide energyLine when there is no significant power

### DIFF
--- a/src/components/energyFlow/energyLine.tsx
+++ b/src/components/energyFlow/energyLine.tsx
@@ -23,7 +23,10 @@ export const EnergyLines: React.FC<EnergyLinesProps> = ({flow, pvPoint, loadPoin
       { Math.abs(flow.additionalSource) > showEnergyThreshold && (
         <>
           <EmptyLine start={extraEnergyPoint} end={{x: pvPoint.x, y: loadPoint.y + 2}}/>
-          <EnergyLine start={extraEnergyPoint} end={{x: pvPoint.x, y: loadPoint.y }} linesColor={linesColor} className={flow.additionalSource < 0 ? "animated-line" : "animated-line-reverse"}/>
+          { Math.abs(flow.additionalSource) > showEnergyThreshold && (
+            <EnergyLine start={extraEnergyPoint} end={{x: pvPoint.x, y: loadPoint.y }} linesColor={linesColor} className={flow.additionalSource < 0 ? "animated-line" : "animated-line-reverse"}/>
+            )
+          }
         </>)
       }
 

--- a/src/components/energyFlow/energyLine.tsx
+++ b/src/components/energyFlow/energyLine.tsx
@@ -9,17 +9,18 @@ interface EnergyLinesProps {
  gridPoint: PointPosition;
  extraEnergyPoint: PointPosition;
  linesColor: string;
+ showEnergyThreshold: number;
 }
 
 
-export const EnergyLines: React.FC<EnergyLinesProps> = ({flow, pvPoint, loadPoint, gridPoint, extraEnergyPoint, linesColor}) => {
+export const EnergyLines: React.FC<EnergyLinesProps> = ({flow, pvPoint, loadPoint, gridPoint, extraEnergyPoint, linesColor, showEnergyThreshold}) => {
   return (
     <>
       <EmptyLine start={{x: pvPoint.x + 2, y: loadPoint.y}} end={gridPoint}/>
       <EmptyLine start={pvPoint} end={{x: pvPoint.x, y: loadPoint.y - 2}}/>
       <EmptyLine start={{x: pvPoint.x - 2, y: loadPoint.y}} end={loadPoint}/>
 
-      {flow.additionalSource !== 0 && (
+      { Math.abs(flow.additionalSource) > showEnergyThreshold && (
         <>
           <EmptyLine start={extraEnergyPoint} end={{x: pvPoint.x, y: loadPoint.y + 2}}/>
           <EnergyLine start={extraEnergyPoint} end={{x: pvPoint.x, y: loadPoint.y }} linesColor={linesColor} className={flow.additionalSource < 0 ? "animated-line" : "animated-line-reverse"}/>
@@ -27,13 +28,22 @@ export const EnergyLines: React.FC<EnergyLinesProps> = ({flow, pvPoint, loadPoin
       }
 
       {/*Grid line*/}
-      <EnergyLine start={{x: pvPoint.x, y: loadPoint.y}} end={gridPoint} linesColor={linesColor} className={flow.grid < 0 ? "animated-line-reverse" : "animated-line"}/>
+      { Math.abs(flow.grid) >= showEnergyThreshold && (
+          <EnergyLine start={{x: pvPoint.x, y: loadPoint.y}} end={gridPoint} linesColor={linesColor} className={flow.grid < 0 ? "animated-line-reverse" : "animated-line"}/>
+        )
+      }
 
       {/*Solar line*/}
-      <EnergyLine start={pvPoint} end={{x: pvPoint.x, y: loadPoint.y}} linesColor={linesColor} className="animated-line-reverse"/>
+      { flow.pv >= showEnergyThreshold && (
+          <EnergyLine start={pvPoint} end={{x: pvPoint.x, y: loadPoint.y}} linesColor={linesColor} className="animated-line-reverse"/>
+        )
+      }
 
       {/*Load line*/}
-      <EnergyLine start={{x: pvPoint.x, y: loadPoint.y}} end={loadPoint} linesColor={linesColor} className="animated-line-reverse"/>
+      { flow.load >= showEnergyThreshold && (
+          <EnergyLine start={{x: pvPoint.x, y: loadPoint.y}} end={loadPoint} linesColor={linesColor} className="animated-line-reverse"/>
+        )
+      }
 
 
     </>

--- a/src/components/energyFlow/index.tsx
+++ b/src/components/energyFlow/index.tsx
@@ -94,7 +94,7 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
                viewBox='0 0 500 500'>
             <EnergyLines flow={flowData} pvPoint={pvPoint}
                          linesColor={(theme.visualization.getColorByName(options.linesColor))} loadPoint={loadPoint}
-                         gridPoint={gridPoint} extraEnergyPoint={additionalPoint} />
+                         gridPoint={gridPoint} extraEnergyPoint={additionalPoint} showEnergyThreshold={options.showEnergyThreshold}/>
           </svg>
         </div>
 
@@ -103,7 +103,7 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
             <Point label="PV" measurementUnit={options.measurementUnit} showLegend={false} value={flowData.pv}
                    style={customPoint(theme.visualization.getColorByName(options.solarColor))} icon={icons["solarPanel"]} />
           </div>
-          {flowData.additionalSource !== 0 && (
+          {Math.abs(flowData.additionalSource) > options.showEnergyThreshold && (
             <div className="point-holder" style={{ position: 'absolute', top: '100px', left: '150px' }}>
               <Point label={options.additionalSourceLabel} measurementUnit={options.measurementUnit} showLegend={options.showLegend} value={flowData.additionalSource}
                      style={customPoint(theme.visualization.getColorByName(options.additionalSourceColor))} icon={icons[options.additionalSourceIcon]} />

--- a/src/module.ts
+++ b/src/module.ts
@@ -54,6 +54,13 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
         ],
       }
     })
+    .addNumberInput({
+        path: 'showEnergyThreshold',
+        name: 'Energy line threshold',
+        description: 'Threshold for showing energy lines',
+        defaultValue: 0,
+      }
+    )
     .addSliderInput(
       {
         path: 'zoom',

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface SimpleOptions {
   extraSourceColor: string;
   loadColor: string;
   gridColor: string;
+  showEnergyThreshold: number;
   zoom: number;
   xOffset: number;
   yOffset: number;


### PR DESCRIPTION
Energy Lines can now be hidden (the empty line is still shown) when power is below a threshold. This makes it easier to identify the power source at a glance.

If the threshold is set to 0 the old behaviour applies (every line is shown).

The additional source is a bit of an outlier - it is not shown, when the theshold is 0.