### PR TITLE
set pointer-events:none on main div

### DIFF
--- a/src/components/energyFlow/index.tsx
+++ b/src/components/energyFlow/index.tsx
@@ -85,6 +85,7 @@ export const EnergyFlow: React.FC<EnergyFlowProps> = ({data, options}) => {
         top: `calc(${(0 - options.yOffset)}px - 50%)`,
         transform: `scale(${options.zoom})`,
         transformOrigin: "270px 0px",
+        pointerEvents: "none",
       }}
     >
       <div>


### PR DESCRIPTION
When zooming is activated, the main div is too big for the panel and overlays other components of grafana. 
For example, on mobile this can lead to preventing the time range from being selected.

As there is no user input being handled in the panel, I've just disabled pointer events on the main div so that they are handled by components that can be seen behind the div.